### PR TITLE
fix link ROOM in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Projeto base da JS Expert Week 2.0
 
 - Acesse o [home](./pages/home/index.html) para acessar a home page
-- Acesse o [room](./page/room/index.html) uma room específica
+- Acesse o [room](./pages/room/index.html) uma room específica
 
 ## Home Page
 


### PR DESCRIPTION
# Link quebrado
Na linha 4, o link para a página ROOM estava quebrado e foi ajustado.

## Link broken
In line four, the link for page ROOM was broken and adjusted